### PR TITLE
Support prune records

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is handled by the [scheduled task](https://devcenter.heroku.com/articles/sc
 To invoke `jq` command, this application requires  [heroku-buildpack-jq](https://github.com/chrismytton/heroku-buildpack-jq) buildpack.
 To serve application server written in Rust, this application requires [heroku-buildpack-rust](https://github.com/emk/heroku-buildpack-rust) buildpack.
 
-## 2. Report bad AQI by email, and
+## 2. Report bad AQI by email
 
 And if AQI is bad, this app calls an IFTTT applet, to send email to owner.
 This email realizes push-notification even when user cannot use push-notification supported by iOS/Android.

--- a/src/controller/aqi.rs
+++ b/src/controller/aqi.rs
@@ -16,7 +16,7 @@ pub fn parse(req: &mut Request) -> IronResult<Response> {
     if quality >= 100 {
         try_submit(quality);
     }
-    let r = ::registry::connect();
+    let r = registry::connect();
     r.insert(quality).unwrap();
     let resp = Response::with((status::Ok, format!("Air quality is {}!", quality)));
     Ok(resp)

--- a/src/controller/aqi.rs
+++ b/src/controller/aqi.rs
@@ -7,6 +7,8 @@ use iron::status;
 use std::env;
 use std::io::Read;
 
+use registry;
+
 pub fn parse(req: &mut Request) -> IronResult<Response> {
     let mut buffer = String::new();
     req.body.read_to_string(&mut buffer).unwrap();
@@ -17,6 +19,16 @@ pub fn parse(req: &mut Request) -> IronResult<Response> {
     let r = ::registry::connect();
     r.insert(quality).unwrap();
     let resp = Response::with((status::Ok, format!("Air quality is {}!", quality)));
+    Ok(resp)
+}
+
+pub fn prune(_req: &mut Request) -> IronResult<Response> {
+    let r = registry::connect();
+    let deleted = r.prune();
+    let resp = Response::with((
+        status::Ok,
+        format!("Deleted {:?} records successfully", deleted.unwrap()),
+    ));
     Ok(resp)
 }
 

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -7,5 +7,6 @@ pub fn initialize() -> Router {
     let mut router: Router = Router::new();
     router.get("/", index::index, "index");
     router.post("/aqi/", aqi::parse, "parse");
+    router.delete("/aqi/", aqi::prune, "prune");
     router
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -29,7 +29,7 @@ impl AqiRegistry {
         Ok(())
     }
 
-    fn prune(&self) -> io::Result<u64> {
+    pub fn prune(&self) -> io::Result<u64> {
         let rows = self.conn.query("SELECT MAX(id) FROM aqi", &[])?;
         let max_id: i32 = rows.get(0).get(0);
         let deleted: u64 = self.conn


### PR DESCRIPTION
Hobby use Heroku has limitation for records in postgres, so it's nice to delete outdated AQI continuously (e.g. weekly). This PR adds API to run `truncate()` method in DAO to support it.